### PR TITLE
Add payment_method_token to transaction if provided

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -467,7 +467,11 @@ module ActiveMerchant #:nodoc:
         end
 
         if credit_card_or_vault_id.is_a?(String) || credit_card_or_vault_id.is_a?(Integer)
-          parameters[:customer_id] = credit_card_or_vault_id
+          if options[:payment_method_token]
+            parameters[:payment_method_token] = credit_card_or_vault_id
+          else
+            parameters[:customer_id] = credit_card_or_vault_id
+          end
         else
           parameters[:customer].merge!(
             :first_name => credit_card_or_vault_id.first_name,


### PR DESCRIPTION
This is a tiny back port inside `create_transaction_parameters` for that takes `payment_method_token` into consideration if provided.
